### PR TITLE
Add Linux installation + testing suport

### DIFF
--- a/Formula/timetrace.rb
+++ b/Formula/timetrace.rb
@@ -16,4 +16,12 @@ class Timetrace < Formula
   def install
     bin.install "timetrace"
   end
+
+  test do
+    assert_predicate bin/"timetrace", :exist?, "binary exists"
+    assert_predicate bin/"timetrace", :executable?, "binary is executable"
+
+    output = shell_output("#{bin}/timetrace --help")
+    assert_match "timetrace", output, "help command contains string 'timetrace'"
+  end
 end

--- a/Formula/timetrace.rb
+++ b/Formula/timetrace.rb
@@ -1,9 +1,18 @@
 class Timetrace < Formula
   desc "Simple time tracking CLI"
   homepage "https://github.com/dominikbraun/timetrace"
-  url "https://github.com/dominikbraun/timetrace/releases/latest/download/timetrace-darwin-amd64.tar.gz"
-  sha256 "4845fc5ea28b71168035615c4d7c766b9763b52bf9516865506a221efb763051"
   version "0.14.3"
+
+  on_macos do
+    url "https://github.com/dominikbraun/timetrace/releases/download/v#{version}/timetrace-darwin-amd64.tar.gz"
+    sha256 "4845fc5ea28b71168035615c4d7c766b9763b52bf9516865506a221efb763051"
+  end
+
+  on_linux do
+    url "https://github.com/dominikbraun/timetrace/releases/download/v#{version}/timetrace-linux-amd64.tar.gz"
+    sha256 "a9d5fb7983578106ab32138ea6a5815755120cc68374140bffddab934f6a3631"
+  end
+
   def install
     bin.install "timetrace"
   end


### PR DESCRIPTION
# Installs on Linux including WSL
- Forumla additionally supports Linux for installation
- tested it locally on my WSL2 system:

````shell
brew install local/tap/timetrace
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Warning: No remote 'origin' in /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/local/homebrew-tap, skipping update!
==> Fetching local/tap/timetrace
==> Downloading https://github.com/dominikbraun/timetrace/releases/download/v0.14.3/timetrace-linux-amd64.tar.gz
Already downloaded: /home/samba/.cache/Homebrew/downloads/c503e15211cdfca4a7929103dac479348df76d33925246e6df5a506b70edab80--timetrace-linux-amd64.tar.gz
==> Installing timetrace from local/tap
🍺  /home/linuxbrew/.linuxbrew/Cellar/timetrace/0.14.3: 4 files, 8.4MB, built in 7 seconds
==> Running `brew cleanup timetrace`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
````

# Random Acts Of Kindness
- install defined *version* instead of "latest" (could be mismatch)
- added "test" block to test the formula
  - needs to run after "install"
  - test output:
  
````shell
brew test local/tap/timetrace
==> Testing local/tap/timetrace
==> /home/linuxbrew/.linuxbrew/Cellar/timetrace/0.14.3/bin/timetrace --help
````  